### PR TITLE
feat: add editor config

### DIFF
--- a/closet/skeletons/.editorconfig
+++ b/closet/skeletons/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/lib/config-helpers/editorconfig.js
+++ b/lib/config-helpers/editorconfig.js
@@ -1,0 +1,17 @@
+const { writeFiles } = require("../fileUtils");
+
+const editorconfigConfigFiles = [".editorconfig"];
+const editorconfigDependencies = [];
+
+const editorconfigConfig = {
+  addConfig: () => {
+    writeFiles(editorconfigConfigFiles);
+    return editorconfigDependencies;
+  },
+};
+
+module.exports = {
+  editorconfigConfigFiles,
+  editorconfigDependencies,
+  editorconfigConfig,
+};

--- a/lib/config-helpers/editorconfig.test.js
+++ b/lib/config-helpers/editorconfig.test.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const mock = require("mock-fs");
+
+const {
+  editorconfigConfigFiles,
+  editorconfigDependencies,
+  editorconfigConfig,
+} = require("./editorconfig");
+
+const defaultFiles = {
+  "closet/skeletons/": {
+    ".editorconfig": "root = true",
+  },
+};
+
+describe("editorconfigConfig.addConfig", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("returns an empty array of dependencies", async () => {
+    mock(defaultFiles);
+
+    let dependencies = await editorconfigConfig.addConfig();
+    expect(dependencies).toStrictEqual(editorconfigDependencies);
+  });
+
+  it("writes skeletons to disk", () => {
+    mock(defaultFiles);
+
+    editorconfigConfig.addConfig();
+
+    editorconfigConfigFiles.forEach((skeleton) => {
+      expect(fs.statSync(skeleton).isFile()).toBe(true);
+    });
+  });
+});

--- a/lib/fill-catacomb.js
+++ b/lib/fill-catacomb.js
@@ -4,6 +4,7 @@ const { complete } = require("./utils");
 const { getConfig } = require("./config");
 
 const { cssTooling } = require("./config-helpers/css");
+const { editorconfigConfig } = require("./config-helpers/editorconfig");
 const { eslintTooling } = require("./config-helpers/eslint");
 const { formatTooling } = require("./config-helpers/format");
 const { jestTooling } = require("./config-helpers/jest");
@@ -51,6 +52,9 @@ async function fillCatacomb() {
         break;
       case "sass":
         dependencies = dependencies.concat(sassTooling.addSass(withPrettier));
+        break;
+      case "editorconfig":
+        dependencies = dependencies.concat(editorconfigConfig.addConfig());
         break;
       case "eslint":
         dependencies = dependencies.concat(


### PR DESCRIPTION
Adds `.editorconfig` skeleton, test, and config entry

fix #192
