### PR TITLE
fix: do not output install cmd if no dependencies

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,10 +27,12 @@ function getInstallCmd(manager, dependencies) {
 function complete(manager, dependencies) {
   signale.success("[Calavera] Skeletons written to project successfully");
 
-  const INSTALL_CMD = getInstallCmd(manager, dependencies);
-  signale.info(
-    `[Calavera] Run the following command to install dependencies: ${INSTALL_CMD}`
-  );
+  if (dependencies.length) {
+    const INSTALL_CMD = getInstallCmd(manager, dependencies);
+    signale.info(
+      `[Calavera] Run the following command to install dependencies: ${INSTALL_CMD}`
+    );
+  }
 }
 
 async function loadPackageJson() {


### PR DESCRIPTION
If there are no dependecies to install, do not output the install command
