### PR TITLE
!feat: install prettier and editorconfig by default

### DIFF
--- a/lib/fill-catacomb.js
+++ b/lib/fill-catacomb.js
@@ -12,53 +12,31 @@ const { sassTooling } = require("./config-helpers/sass");
 const { typescriptTooling } = require("./config-helpers/typescript");
 
 async function fillCatacomb() {
-  const calaveraConfig = await getConfig();
+  let calaveraConfig = await getConfig();
 
   if (!calaveraConfig) {
-    signale.info(
-      "No configuration found for calavera. Please add a config block in your package.json"
-    );
-    return;
+    signale.info("Writing default Prettier and editorconfig files");
+    calaveraConfig = { default: true };
   }
 
-  const configKeys = Object.keys(calaveraConfig);
   let dependencies = [];
   let manager = "yarn";
-  let withPrettier = false;
-
-  /* If there is more than one entry in calaveraConfig, determine
-   * if Prettier is one of the entries. If Prettier is found, see if
-   * we also have either css, sass, or eslint as a config entry.
-   *
-   * If the above is true, set withPrettier to true and delete prettier
-   * from calaveraConfig. This is to avoid duplication of Prettier
-   * dependencies as well as duplicate file writes.
-   */
-  if (
-    configKeys.length > 1 &&
-    configKeys.includes("prettier") &&
-    (configKeys.includes("css") ||
-      configKeys.includes("sass") ||
-      configKeys.includes("eslint"))
-  ) {
-    withPrettier = true;
-    delete calaveraConfig["prettier"];
-  }
 
   for (let config in calaveraConfig) {
     switch (config) {
       case "css":
-        dependencies = dependencies.concat(cssTooling.addLinting(withPrettier));
+        dependencies = dependencies.concat(
+          cssTooling.addLinting(true /* withPrettier: true */)
+        );
         break;
       case "sass":
-        dependencies = dependencies.concat(sassTooling.addSass(withPrettier));
-        break;
-      case "editorconfig":
-        dependencies = dependencies.concat(editorconfigConfig.addConfig());
+        dependencies = dependencies.concat(
+          sassTooling.addSass(true /* withPrettier: true */)
+        );
         break;
       case "eslint":
         dependencies = dependencies.concat(
-          eslintTooling.addLinting(withPrettier)
+          eslintTooling.addLinting(true /* withPrettier: true */)
         );
         break;
       case "jest":
@@ -67,16 +45,15 @@ async function fillCatacomb() {
       case "manager":
         manager = config;
         break;
-      case "prettier":
-        dependencies = dependencies.concat(formatTooling.addPrettier());
-        break;
       case "typescript":
         dependencies = dependencies.concat(
           typescriptTooling.addTooling(calaveraConfig[config])
         );
         break;
       default:
-        signale.error(`No configuration or skeleton match found for ${config}`);
+        dependencies = dependencies.concat(editorconfigConfig.addConfig());
+        dependencies = dependencies.concat(formatTooling.addPrettier());
+        signale.info(`Adding Prettier and .editorconfig by default`);
         break;
     }
   }

--- a/lib/fill-catacomb.test.js
+++ b/lib/fill-catacomb.test.js
@@ -4,67 +4,48 @@ const mock = require("mock-fs");
 const { fillCatacomb } = require("./fill-catacomb");
 const { cssConfigFiles } = require("./config-helpers/css");
 const { prettierConfigFiles } = require("./config-helpers/format");
+const { editorconfigConfigFiles } = require("./config-helpers/editorconfig");
 
 describe("fillCatacomb", () => {
   afterEach(() => {
     mock.restore();
   });
 
-  it("writes .prettierrc.json to root directory for prettier config", async () => {
+  it("writes .prettierrc.json and .editorconfig to root directory by default", async () => {
     mock({
       "package.json": JSON.stringify({
         name: "project-calavera",
         version: "0.0.0-semantically-released",
-        calavera: {
-          prettier: true,
-        },
       }),
       "closet/skeletons/": {
         ".prettierrc.json": "{}",
+        ".prettierignore": "# Ignore artifacts:",
+        ".editorconfig": "root = true",
       },
     });
 
     await fillCatacomb();
 
     expect(fs.existsSync(prettierConfigFiles[0])).toBe(true);
+    expect(fs.existsSync(prettierConfigFiles[1])).toBe(true);
+    expect(fs.existsSync(editorconfigConfigFiles[0])).toBe(true);
   });
 
-  it("writes relevant config files to root directory for css config - no prettier", async () => {
+  it("writes relevant config files to root directory for css config", async () => {
     mock({
       "package.json": JSON.stringify({
         name: "project-calavera",
         version: "0.0.0-semantically-released",
         calavera: {
           css: true,
-        },
-      }),
-      "closet/skeletons/": {
-        ".stylelintrc": "{}",
-        ".stylelintignore": "{}",
-      },
-    });
-
-    await fillCatacomb();
-
-    cssConfigFiles.forEach((skeleton) => {
-      expect(fs.statSync(skeleton).isFile()).toBe(true);
-    });
-  });
-
-  it("writes relevant config files to root directory for css config - with prettier", async () => {
-    mock({
-      "package.json": JSON.stringify({
-        name: "project-calavera",
-        version: "0.0.0-semantically-released",
-        calavera: {
-          css: true,
-          prettier: true,
         },
       }),
       "closet/skeletons/": {
         ".stylelintrc": `{"extends":["stylelint-a11y/recommended"]}`,
         ".stylelintignore": "{}",
         ".prettierrc.json": "{}",
+        ".prettierignore": "# Ignore artifacts:",
+        ".editorconfig": "root = true",
       },
     });
 


### PR DESCRIPTION
We now add Prettier and `.editorconfig` by default if no config is present

fix #234
