### PR TITLE
fix: bump ecma version

### DIFF
--- a/closet/skeletons/.eslintrc.json
+++ b/closet/skeletons/.eslintrc.json
@@ -5,7 +5,7 @@
   },
   "plugins": ["import"],
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2021
   },
   "env": {
     "es6": true,

--- a/closet/skeletons/jest/.eslintrc.json
+++ b/closet/skeletons/jest/.eslintrc.json
@@ -10,7 +10,7 @@
   },
   "plugins": ["import"],
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2021
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
Bump the `ecmaVersion` to 2021

fix #305
