### PR TITLE
fix:deps ~ switch to sass from node-sass-chokidar

### DIFF
--- a/lib/config-helpers/sass.js
+++ b/lib/config-helpers/sass.js
@@ -11,7 +11,6 @@ const sassDependencies = [
   "stylelint-a11y",
   "stylelint-config-recommended",
   "sass",
-  "node-sass-chokidar",
   "stylelint-scss",
   "stylelint-config-sass-guidelines",
 ];


### PR DESCRIPTION
Use `sass` as the dependency as opposed to `node-sass[-chokidar]`

fix #398
