### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,16 +3,22 @@ on: [pull_request]
 
 jobs:
   test:
-    name: test-calavera
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node_version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       - name: Install dependencies
-        run: |
-          yarn install
+        run: yarn install --frozen-lockfile
       - name: Run tests
-        run: |
-          yarn test
+        run: yarn test


### PR DESCRIPTION
- Run against Node.js `14.x, 16.x, 18.x`
- Enable yarn cache
- Run `yarn install --frozen-lockfile`
- General syntax cleanup