### PR TITLE
add windows to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node_version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 


### PR DESCRIPTION
As this tool can be used on Linux and Windows, we should also run tests against a Windows environment.